### PR TITLE
BUGFIX - When using multichoice with long texts, the text is breaking out of the card

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -28,3 +28,7 @@ html, body {
   white-space: unset!important;
   margin: -5px 6px 10px 6px !important;
 }
+
+.ac-input div input[type="checkbox"]:checked + div{
+  color: #0177ca!important
+}

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -22,3 +22,9 @@ html, body {
 #botContainer.wc-display {
   display: block;
 }
+
+.ac-input div input[type="checkbox"] + div{
+  flex: auto !important;
+  white-space: unset!important;
+  margin: -5px 6px 10px 6px !important;
+}


### PR DESCRIPTION
Issue: When using multichoice with long texts, the text is breaking out of the card instead of either breaking or getting cut (elipsis).
  
The fix will force the word break approach so the end user will see the entire text of the choice option and not just a portion of it.

