### PR TITLE
Use POST for the token

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -2,7 +2,7 @@ function requestChatBot() {
     const oReq = new XMLHttpRequest();
     oReq.addEventListener("load", initBotConversation);
     var path = "/chatBot";
-    oReq.open("GET", path);
+    oReq.open("POST", path);
     oReq.send();
 }
 

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ function isUserAuthenticated(){
     return true;
 }
 
-app.get('/chatBot',  function(req, res) {
+app.post('/chatBot',  function(req, res) {
     if (!isUserAuthenticated()) {
         res.status(403).send();
         return


### PR DESCRIPTION
When `GET` is used, browser may cache the result.

It should use `POST` instead.