### PR TITLE
GET uses Caching

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -10,7 +10,7 @@ function requestChatBot(loc) {
     if (params['userId']) {
         path += "&userId=" + params['userId'];
     }
-    oReq.open("GET", path);
+    oReq.open("POST", path);
     oReq.send();
 }
 

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ function isUserAuthenticated(){
     return true;
 }
 
-app.get('/chatBot',  function(req, res) {
+app.post('/chatBot',  function(req, res) {
     if (!isUserAuthenticated()) {
         res.status(403).send();
         return


### PR DESCRIPTION
When GET is used, browser may cache the result.

It should use POST instead.