### PR TITLE
Deploy to azure button with ARM template

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@ A simple web page to hand off users to the Microsoft Health bot
 
 1. Deploy the website:
 
-[![Deploy to Azure][Deploy Button]][Deploy Node/GetConversationMembers]
-
-[Deploy Button]: https://azuredeploy.net/deploybutton.png
-[Deploy Node/GetConversationMembers]: https://azuredeploy.net
- 
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbalteravishay%2FHealthBotContainerSample%2Favbalter%2F305-deploy-to-azure%2Fazuredeploy.json)
 
 2.Set the following environment variables:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple web page to hand off users to the Microsoft Health bot
 
 1. Deploy the website:
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbalteravishay%2FHealthBotContainerSample%2Favbalter%2F305-deploy-to-azure%2Fazuredeploy.json)
+[![Deploy to Azure](https://azuredeploy.net/deploybutton.png)](https://azuredeploy.net/)
 
 2.Set the following environment variables:
 

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -40,13 +40,13 @@
                 "description": "Location for all resources."
             }
         },
-        "app_secret": {
+        "appSecret": {
             "type": "securestring",
             "metadata":{
                 "description": "Healthbot application secret."
             }
         },
-        "webchat_secret": {
+        "webchatSecret": {
             "type": "securestring",
             "metadata":{
                 "description": "Healthbot webchat secret."   
@@ -79,11 +79,11 @@
                     "appSettings": [
                         {
                         "name": "APP_SECRET",
-                        "value": "[parameters('app_secret')]"
+                        "value": "[parameters('appSecret')]"
                         },
                         {
                         "name": "WEBCHAT_SECRET",
-                        "value": "[parameters('webchat_secret')]"
+                        "value": "[parameters('webchatSecret')]"
                         }
                     ]
                 },

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -35,7 +35,6 @@
         },
         "location": {
             "type": "string",
-            "defaultValue": "[resourceGroup().location]",
             "metadata":{
                 "description": "Location for all resources."
             }

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,0 +1,126 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "siteName": {
+            "type": "string",
+            "defaultValue": "[concat('HealthBot', uniqueString(resourceGroup().name, utcNow('F')))]",
+            "metadata":{
+                "description": "Web site name. Has to be unique."
+                
+            }
+        },
+        "skuName": {
+            "type": "string",
+            "defaultValue": "P1V2",
+            "allowedValues": [
+                "F1",
+                "D1",
+                "B1",
+                "B2",
+                "B3",
+                "S1",
+                "S2",
+                "S3",
+                "P1",
+                "P2",
+                "P3",
+                "P1V2",
+                "P2V2",
+                "P3V2"
+            ],
+            "metadata": {
+                "description": "Describes plan's pricing tier and instance size. Check details at https://azure.microsoft.com/en-us/pricing/details/app-service/"
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata":{
+                "description": "Location for all resources."
+            }
+        },
+        "app_secret": {
+            "type": "securestring",
+            "metadata":{
+                "description": "Healthbot application secret."
+            }
+        },
+        "webchat_secret": {
+            "type": "securestring",
+            "metadata":{
+                "description": "Healthbot webchat secret."   
+            }
+        }
+    },
+    "variables":{
+        "alwaysOn": true,
+        "skuCode": "[parameters('skuName')]",
+        "numberOfWorkers": "3",
+        "linuxFxVersion": "NODE|lts",
+        "hostingPlanName": "[concat('hpn-', parameters('siteName'))]",
+        "repoURL": "https://github.com/microsoft/HealthBotContainerSample.git",
+        "branch": "master"
+    },
+    "resources": [
+        {
+            "apiVersion": "2018-02-01",
+            "name": "[parameters('siteName')]",
+            "type": "Microsoft.Web/sites",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms/', variables('hostingPlanName'))]"
+            ],
+            "properties": {
+                "name": "[parameters('siteName')]",
+                "siteConfig": {
+                    "linuxFxVersion": "[variables('linuxFxVersion')]",
+                    "alwaysOn": "[variables('alwaysOn')]",
+                    "appSettings": [
+                        {
+                        "name": "APP_SECRET",
+                        "value": "[parameters('app_secret')]"
+                        },
+                        {
+                        "name": "WEBCHAT_SECRET",
+                        "value": "[parameters('webchat_secret')]"
+                        }
+                    ]
+                },
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+                "clientAffinityEnabled": false
+            },
+            "resources": [
+                {
+                    "type": "sourcecontrols",
+                    "apiVersion": "2018-02-01",
+                    "name": "web",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Web/sites', parameters('siteName'))]"
+                    ],
+                    "properties": {
+                        "repoUrl": "[variables('repoURL')]",
+                        "branch": "[variables('branch')]",
+                        "isManualIntegration": true
+                    }
+                }
+            ]
+        },
+        {
+            "apiVersion": "2018-02-01",
+            "name": "[variables('hostingPlanName')]",
+            "type": "Microsoft.Web/serverfarms",
+            "location": "[parameters('location')]",
+            "kind": "linux",
+            "sku": {
+                "Name": "[variables('skuCode')]"
+            },
+            "properties": {
+                "name": "[variables('hostingPlanName')]",
+                "numberOfWorkers": "[variables('numberOfWorkers')]",
+                "reserved": true
+            }
+        }
+    ]
+}

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -33,6 +33,13 @@
                 "description": "Describes plan's pricing tier and instance size. Check details at https://azure.microsoft.com/en-us/pricing/details/app-service/"
             }
         },
+        "numberOfInstances": {
+            "type": "int",
+            "defaultValue": 2,
+            "metadata":{
+                "description": "Number of instances the app service is scaled to. Check the maximum instances your plan can host at https://azure.microsoft.com/en-us/pricing/details/app-service"
+            }
+        },
         "siteLocation": {
             "type": "string",
             "metadata":{
@@ -55,7 +62,7 @@
     "variables":{
         "alwaysOn": true,
         "skuCode": "[parameters('skuName')]",
-        "numberOfWorkers": "3",
+        "numberOfWorkers": "[parameters('numberOfInstances')]",
         "linuxFxVersion": "NODE|lts",
         "hostingPlanName": "[concat('hpn-', parameters('siteName'))]",
         "repoURL": "https://github.com/microsoft/HealthBotContainerSample.git",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -33,7 +33,7 @@
                 "description": "Describes plan's pricing tier and instance size. Check details at https://azure.microsoft.com/en-us/pricing/details/app-service/"
             }
         },
-        "location": {
+        "siteLocation": {
             "type": "string",
             "metadata":{
                 "description": "Location for all resources."
@@ -66,7 +66,7 @@
             "apiVersion": "2018-02-01",
             "name": "[parameters('siteName')]",
             "type": "Microsoft.Web/sites",
-            "location": "[parameters('location')]",
+            "location": "[parameters('siteLocation')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms/', variables('hostingPlanName'))]"
             ],
@@ -94,7 +94,7 @@
                     "type": "sourcecontrols",
                     "apiVersion": "2018-02-01",
                     "name": "web",
-                    "location": "[parameters('location')]",
+                    "location": "[parameters('siteLocation')]",
                     "dependsOn": [
                         "[resourceId('Microsoft.Web/sites', parameters('siteName'))]"
                     ],
@@ -110,7 +110,7 @@
             "apiVersion": "2018-02-01",
             "name": "[variables('hostingPlanName')]",
             "type": "Microsoft.Web/serverfarms",
-            "location": "[parameters('location')]",
+            "location": "[parameters('siteLocation')]",
             "kind": "linux",
             "sku": {
                 "Name": "[variables('skuCode')]"


### PR DESCRIPTION
This PR adds an ARM template for the health-bot App Service using linux based plan with Node.JS latest, and three workers. 
The "Deploy to Azure" functionality is changed to use this template and now supports the APP_SECRET and WEBCHAT_SECRET configurations.