### PR TITLE
Get User Location By IP Address

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -1,5 +1,6 @@
 const defaultLocale = 'en-US';
 const localeRegExPattern = /^[a-z]{2}(-[A-Z]{2})?$/;
+const ipLocationLookupEndpoint = 'https://geolocation-db.com/jsonp';
 
 function requestChatBot(loc) {
     const params = new URLSearchParams(location.search);
@@ -45,8 +46,8 @@ function chatRequested() {
 
 function getUserLocation(callback) {
     navigator.geolocation.getCurrentPosition(
-        function(position) {
-            var latitude  = position.coords.latitude;
+        function (position) {
+            var latitude = position.coords.latitude;
             var longitude = position.coords.longitude;
             var location = {
                 lat: latitude,
@@ -54,11 +55,31 @@ function getUserLocation(callback) {
             }
             callback(location);
         },
-        function(error) {
+        function (error) {
             // user declined to share location
             console.log("location error:" + error.message);
-            callback();
+            // Get Location via IP
+            getUserLocationIp(callback);
         });
+}
+
+function getUserLocationIp(callback) {
+    const oReq = new XMLHttpRequest();
+    oReq.open("GET", ipLocationLookupEndpoint, true);
+    oReq.onload = function () {
+        var position = JSON.parse(this.response);
+        console.log("IP Position: " + JSON.stringify(position));
+        if (oReq.status >= 200 && oReq.status <= 400) {
+            var latitude = position.latitude;
+            var longitude = position.longitude;
+            var location = { lat: latitude, long: longitude };
+            callback(location);
+        }
+        else {
+            callback();
+        }
+    }
+    oReq.send();
 }
 
 function initBotConversation() {


### PR DESCRIPTION
The Health Bot Container Sample has code that leverages HTML5 geolocation API. that allows a web page’s visitor to share their location with you if they so choose. The key statement being if they so choose hence, the issue is the user has to give us permission to their location. If they don't give permission then the chat bot cannot acquire the user's location and the calls to the geolocation API services will not provide a location.

Secondly, if the user is using an older browser, like say Opera or IE 10, the geolocation API is not available and you won't be able to acquire the location in this situation either.
In my research I found 3 IP Geolocation services that seemed to be the most popular. Here are the three APIs I found.

- (Used in the sample code) GeoLocation DB - Open & seems FREE as no license information is available on the site. No sign up required.

- IP Geolocation API - Open and Free of non-commercial use. No sign up required. If you exceed the usage limit of 45 requests per minute your access to the API will be temporarily blocked. Repeatedly exceeding the limit will result in your IP address being banned for up to 1 hour. See the Terms

- IPinfo - Account required Free usage of the API is limited to 50,000 API requests per month.

This pull request adds the IP address as a way to get the user's location. 