### PR TITLE
Removing locale validation

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -1,12 +1,10 @@
 const defaultLocale = 'en-US';
-const localeRegExPattern = /^[a-z]{2}(-[A-Z]{2})?$/;
 
 function requestChatBot(loc) {
     const params = new URLSearchParams(location.search);
-    const locale = params.has('locale') ? extractLocale(params.get('locale')) : defaultLocale;
     const oReq = new XMLHttpRequest();
     oReq.addEventListener("load", initBotConversation);
-    var path = "/chatBot?locale=" + locale;
+    var path = "/chatBot?locale=" + extractLocale(params.get('locale'));
 
     if (loc) {
         path += "&lat=" + loc.lat + "&long=" + loc.long;
@@ -22,15 +20,15 @@ function requestChatBot(loc) {
 }
 
 function extractLocale(localeParam) {
-    if(localeParam === 'autodetect') {
+    if (!localeParam) {
+        return defaultLocale;
+    }
+    else if (localeParam === 'autodetect') {
         return navigator.language;
     }
-
-    //Before assigning, ensure it's a valid locale string (xx or xx-XX)
-    if(localeParam.search(localeRegExPattern) === 0) {
+    else {
         return localeParam;
     }
-    return defaultLocale;
 }
 
 function chatRequested() {

--- a/server.js
+++ b/server.js
@@ -1,6 +1,4 @@
 require('dotenv').config();
-const defaultLocale = 'en-US';
-const localeRegExPattern = /^[a-z]{2}(-[A-Z]{2})?$/;
 const crypto = require('crypto');
 const express = require("express");
 const path = require("path");
@@ -29,13 +27,6 @@ app.listen(port, function() {
 function isUserAuthenticated(){
     // add here the logic to verify the user is authenticated
     return true;
-}
-
-function getValidatedLocale(loc) {
-    if (loc.search(localeRegExPattern) === 0) {
-        return loc;
-    }
-    return defaultLocale;
 }
 
 const appConfig = {
@@ -96,7 +87,7 @@ app.post('/chatBot',  function(req, res) {
             var response = {};
             response['userId'] = userid;
             response['userName'] = req.query.userName;
-            response['locale'] = getValidatedLocale(req.query.locale);
+            response['locale'] = req.query.locale;
             response['connectorToken'] = parsedBody.token;
 
             /*


### PR DESCRIPTION
Removing locale validation:
Current locale validation doesn't support all cases, such as: de, zh-Hant-TW, En-au,aZ_cYrl-aZ
The locale is validated in the WebChat app anyway so it's redundant.