### PR TITLE
Static content serving changes

### DIFF
--- a/Web.config
+++ b/Web.config
@@ -24,11 +24,6 @@
           <match url="^server.js\/debug[\/]?" />
         </rule>
 
-        <!-- First we consider whether the incoming URL matches a physical file in the /public folder -->
-        <rule name="StaticContent">
-          <action type="Rewrite" url="public{REQUEST_URI}"/>
-        </rule>
-
         <!-- All other URLs are mapped to the node.js site entry point -->
         <rule name="DynamicContent">
           <conditions>

--- a/server.js
+++ b/server.js
@@ -13,9 +13,13 @@ const directLineTokenEp = `https://${DIRECTLINE_ENDPOINT_URI || "directline.botf
 // Initialize the web app instance,
 const app = express();
 app.use(cookieParser());
+
+let options = {};
+// uncomment the line below if you wish to allow only specific domains to embed this page as a frame
+//options = {setHeaders: (res, path, stat) => {res.set('Content-Security-Policy', 'frame-ancestors example.com')}};
 // Indicate which directory static resources
 // (e.g. stylesheets) should be served from.
-app.use(express.static(path.join(__dirname, "public")));
+app.use(express.static(path.join(__dirname, "public"), options));
 // begin listening for requests.
 const port = process.env.PORT || 8080;
 const region = process.env.REGION || "Unknown";


### PR DESCRIPTION
1. Serving static content from express.js on all platforms (not using iis for windows)
2. adding code sample in server.js for how to use content security policy to limit the domains that are allowed to embed the page as a frame