### PR TITLE
Remove the gzip file extension

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
         );window[aiName]=aisdk,aisdk.queue&&0===aisdk.queue.length&&aisdk.trackPageView({});
     </script>
     -->
-    <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat-es5.gzip.js"></script>
+    <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat-es5.js"></script>
     <script src="index.js"></script>
     <link href="stylesheets/style.css" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
The regular webchat file is gzipped by default and the version with the gzip file extension is no longer needed.  