### PR TITLE
Node.js version for Windows App Service

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -89,7 +89,7 @@
         "workerSize": "0",
         "workerSizeId": "0",
         "hostingEnvironment": "",
-        "nodeVersion": "16.13.0",
+        "nodeVersion": "~16",
         "currentStack": "node"
     },
     "resources": [


### PR DESCRIPTION
Switch to using tilda notation, and pointing only to a major version, instead of pointing to a specific version that may be removed at some point.
We choose 16 because this is the current LTS