### PR TITLE
Pin Dockerfile to Node.js 20 LTS

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:20
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
## Summary

- `node:latest` now resolves to Node.js v25, which removed `SlowBuffer` from the `buffer` module
- This breaks `buffer-equal-constant-time@1.0.1` (transitive dep of `jsonwebtoken@8.5.1`), causing a `TypeError` at container startup
- Pinning to `node:20` (active LTS) fixes the crash and avoids future breakage from unpinned base images

## Error

```
/usr/src/app/node_modules/buffer-equal-constant-time/index.js:37
var origSlowBufEqual = SlowBuffer.prototype.equal;
                                  ^
TypeError: Cannot read properties of undefined (reading 'prototype')
```

## Root cause

`jsonwebtoken@8.5.1` → `jwa` → `buffer-equal-constant-time@1.0.1` uses `require('buffer').SlowBuffer`, which was deprecated in Node v6 and removed in Node v25.

## Test plan

- [x] Built and ran container with `node:20` — starts cleanly, no errors
- [x] Verified `Express server listening on port 8080` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)